### PR TITLE
doc: add JTAG pinout docs

### DIFF
--- a/doc/jtag.md
+++ b/doc/jtag.md
@@ -1,0 +1,7 @@
+# JTAG pinout (set by u-boot)
+
+| Left Pins               | Right Pins                 |
+|-------------------------|----------------------------|
+| TMS(20): Pin 35, GPIO63 |  RST(4): Pin 36, GPIO36    |
+| TCK(29): Pin 37, GPIO60 |  TDI(19): Pin 38, GPIO61   |
+|                         |  TDO(8,22): Pin 40, GPIO44 |


### PR DESCRIPTION
Adds documentation for JTAG pinout configuration set by `u-boot` firmware on VisionFive2 boards.